### PR TITLE
Feature/metamask login

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,8 @@ const loginWithMM = async () => {
             console.log(result, 'ress')
         }
     ).catch(err => console.error(err))
-}```
+}
+```
 
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -43,6 +43,52 @@ Getting a list of detected issues
 await mythx.getDetectedIssues('1111-2222-3333-4444')
 ```
 
+### Logging in with MetaMask
+In order to keep MythXJS as lean as possible we do not handle MetaMask integration ourself. Instead we provide two methods: getChallenge() and loginWithSignature() and leave the user handle the MetaMask integration the way they better prefer on their front end. This also lets the user work with their preffered version of `web3`.
+
+Example using react app and `web3@1.0.0-beta.37`:
+```
+const handleSignMessage = (account, data) => {
+    try {
+        return new Promise((resolve) => {
+            const {value} = data.message
+            if (!account) {
+              console.error('no-account')
+            }
+              const params = [account, JSON.stringify(data)]
+              web3.currentProvider.send(
+                        { method: 'eth_signTypedData_v3', params, from: account },
+                        (err, result) => {
+                          if (err || result.error) {
+                            console.error('Error with handling signature.', err)
+                          }
+                          resolve(value + '.' + result.result)
+                        }
+                    )
+            }).catch((error) => {
+              console.error(error)
+            })
+    } catch(err) {
+        console.error(err)
+    }
+}
+
+const loginWithMM = async () => {
+    const accounts = await web3.eth.getAccounts();
+    const account = accounts[0]
+
+    const data = await mythx.getChallenge(account.toLowerCase())
+    
+    handleSignMessage(account, data).then(
+        async (message) => {
+            // Returns set of tokens
+            const result = await mythx.loginWithSignature(message)
+            console.log(result, 'ress')
+        }
+    ).catch(err => console.error(err))
+}```
+
+
 ## Documentation
 For a complete list of functionality available on the library please check our [docs](https://consensys.github.io/mythxjs/classes/_apiservices_clientservice_.clientservice.html)
 

--- a/src/apiServices/AuthService.ts
+++ b/src/apiServices/AuthService.ts
@@ -33,10 +33,13 @@ export class AuthService {
         }
     }
 
-    public async loginWithSignature(signature: string): Promise<JwtTokensInterface | void> {
+    public async loginWithSignature(
+        signature: string,
+        provider: string = 'MetaMask',
+    ): Promise<JwtTokensInterface | void> {
         try {
             const headers = {
-                Authorization: `MetaMask ${signature}`,
+                Authorization: `${provider} ${signature}`,
             }
             const result = await postRequest(`${API_URL_PRODUCTION}/auth/login`, null, headers)
             const tokens: JwtTokensInterface = result.data.jwtTokens

--- a/src/apiServices/AuthService.ts
+++ b/src/apiServices/AuthService.ts
@@ -137,7 +137,7 @@ export class AuthService {
             const result = await getRequest(`${API_URL_PRODUCTION}/auth/challenge?ethAddress=${this.ethAddress}`, {})
             return result.data
         } catch (err) {
-            console.error(err)
+            errorHandler(err)
         }
     }
 

--- a/src/apiServices/AuthService.ts
+++ b/src/apiServices/AuthService.ts
@@ -33,6 +33,13 @@ export class AuthService {
         }
     }
 
+    /**
+     *  Login to the API using metamask challenge result message.
+     *  In order to get the object containing the message use `getChallenge` and handle Metamask login in the frontend.
+     * @param signature message.value property contained in object returned from `getChallenge`.
+     * @param provider pass a provider value for the HTTP headers. If nothing is passed defaults to MetaMask
+     * @return {Promise<JwtTokensInterface>}  Returns an object containing two tokens (access+refresh) that can be saved in storage.
+     */
     public async loginWithSignature(
         signature: string,
         provider: string = 'MetaMask',
@@ -135,6 +142,11 @@ export class AuthService {
         }
     }
 
+    /**
+     *  Generates authentication challenge (Metamask only for now).
+     *  The Metamask flow needs to be handled on the front end since MythXJS does not have Web3 dependencies.
+     * @returns Resolves with API response or throw error
+     */
     public async getChallenge(): Promise<any | void> {
         try {
             const result = await getRequest(`${API_URL_PRODUCTION}/auth/challenge?ethAddress=${this.ethAddress}`, {})

--- a/src/apiServices/AuthService.ts
+++ b/src/apiServices/AuthService.ts
@@ -39,7 +39,7 @@ export class AuthService {
 
     /**
      *  Login to the API using metamask challenge result message.
-     *  In order to get the object containing the message use `getChallenge` and handle Metamask login in the frontend.
+     *  In order to get the object containing the message, use `getChallenge` and handle Metamask login in the frontend.
      * @param signature message.value property contained in object returned from `getChallenge`.
      * @param provider pass a provider value for the HTTP headers. If nothing is passed defaults to MetaMask
      * @return {Promise<JwtTokensInterface>}  Returns an object containing two tokens (access+refresh) that can be saved in storage.
@@ -154,8 +154,7 @@ export class AuthService {
      */
     public async getChallenge(ethAddress?: string): Promise<any | void> {
         try {
-            let address
-            ethAddress ? (address = ethAddress) : (address = this.ethAddress)
+            const address = ethAddress ? ethAddress : this.ethAddress
             const result = await getRequest(`${API_URL_PRODUCTION}/auth/challenge?ethAddress=${address}`, {})
             return result.data
         } catch (err) {

--- a/src/apiServices/AuthService.ts
+++ b/src/apiServices/AuthService.ts
@@ -149,11 +149,14 @@ export class AuthService {
     /**
      *  Generates authentication challenge (Metamask only for now).
      *  The Metamask flow needs to be handled on the front end since MythXJS does not have Web3 dependencies.
+     * @param ethAddress Ethereum address for Mythx account
      * @returns Resolves with API response or throw error
      */
-    public async getChallenge(): Promise<any | void> {
+    public async getChallenge(ethAddress?: string): Promise<any | void> {
         try {
-            const result = await getRequest(`${API_URL_PRODUCTION}/auth/challenge?ethAddress=${this.ethAddress}`, {})
+            let address
+            ethAddress ? (address = ethAddress) : (address = this.ethAddress)
+            const result = await getRequest(`${API_URL_PRODUCTION}/auth/challenge?ethAddress=${address}`, {})
             return result.data
         } catch (err) {
             errorHandler(err)

--- a/src/apiServices/AuthService.ts
+++ b/src/apiServices/AuthService.ts
@@ -33,6 +33,21 @@ export class AuthService {
         }
     }
 
+    public async loginWithMetamask(message: string): Promise<JwtTokensInterface | void> {
+        try {
+            const headers = {
+                Authorization: `MetaMask ${message}`,
+            }
+            const result = await postRequest(`${API_URL_PRODUCTION}/auth/login`, null, headers)
+            const tokens: JwtTokensInterface = result.data.jwtTokens
+            this.setCredentials(tokens)
+
+            return tokens
+        } catch (err) {
+            errorHandler(err)
+        }
+    }
+
     public async logout() {
         if (this.isUserLoggedIn()) {
             try {
@@ -114,6 +129,15 @@ export class AuthService {
             }
         } else {
             throw new Error('MythxJS no valid token found. Please login.')
+        }
+    }
+
+    public async getChallenge(): Promise<any | void> {
+        try {
+            const result = await getRequest(`${API_URL_PRODUCTION}/auth/challenge?ethAddress=${this.ethAddress}`, {})
+            return result.data
+        } catch (err) {
+            console.error(err)
         }
     }
 

--- a/src/apiServices/AuthService.ts
+++ b/src/apiServices/AuthService.ts
@@ -33,10 +33,10 @@ export class AuthService {
         }
     }
 
-    public async loginWithMetamask(message: string): Promise<JwtTokensInterface | void> {
+    public async loginWithMetamask(signature: string): Promise<JwtTokensInterface | void> {
         try {
             const headers = {
-                Authorization: `MetaMask ${message}`,
+                Authorization: `MetaMask ${signature}`,
             }
             const result = await postRequest(`${API_URL_PRODUCTION}/auth/login`, null, headers)
             const tokens: JwtTokensInterface = result.data.jwtTokens

--- a/src/apiServices/AuthService.ts
+++ b/src/apiServices/AuthService.ts
@@ -21,8 +21,12 @@ export class AuthService {
         this.password = password as string
     }
 
-    public async login(): Promise<JwtTokensInterface | undefined> {
+    public async login(ethAddress?: string, password?: string): Promise<JwtTokensInterface | undefined> {
         try {
+            if (ethAddress && password) {
+                this.ethAddress = ethAddress
+                this.password = password
+            }
             const result = await loginUser(this.ethAddress, this.password, `${API_URL_PRODUCTION}/auth/login`)
             const tokens: JwtTokensInterface = result.data.jwtTokens
             this.setCredentials(tokens)

--- a/src/apiServices/AuthService.ts
+++ b/src/apiServices/AuthService.ts
@@ -33,7 +33,7 @@ export class AuthService {
         }
     }
 
-    public async loginWithMetamask(signature: string): Promise<JwtTokensInterface | void> {
+    public async loginWithSignature(signature: string): Promise<JwtTokensInterface | void> {
         try {
             const headers = {
                 Authorization: `MetaMask ${signature}`,

--- a/src/apiServices/ClientService.ts
+++ b/src/apiServices/ClientService.ts
@@ -70,10 +70,11 @@ export class ClientService {
      *  Login to the API using metamask challenge result message.
      *  In order to get the object containing the message use `getChallenge` and handle Metamask login in the frontend.
      * @param signature message.value property contained in object returned from `getChallenge`.
+     * @param provider pass a provider value for the HTTP headers. If nothing is passed defaults to MetaMask
      * @return {Promise<JwtTokensInterface>}  Returns an object containing two tokens (access+refresh) that can be saved in storage.
      */
-    async loginWithSignature(signature: string): Promise<JwtTokensInterface | void> {
-        return await this.authService.loginWithSignature(signature)
+    async loginWithSignature(signature: string, provider: string): Promise<JwtTokensInterface | void> {
+        return await this.authService.loginWithSignature(signature, provider)
     }
 
     /**

--- a/src/apiServices/ClientService.ts
+++ b/src/apiServices/ClientService.ts
@@ -75,7 +75,7 @@ export class ClientService {
     /**
      *  Login to the API using metamask challenge result message.
      *  In order to get the object containing the message use `getChallenge` and handle Metamask login in the frontend.
-     * @param signature message.value property contained in object returned from `getChallenge`.
+     * @param signature Signature passed by provider. In case of metamask this will be returned after signing challenge.
      * @param provider pass a provider value for the HTTP headers. If nothing is passed defaults to MetaMask
      * @return {Promise<JwtTokensInterface>}  Returns an object containing two tokens (access+refresh) that can be saved in storage.
      */

--- a/src/apiServices/ClientService.ts
+++ b/src/apiServices/ClientService.ts
@@ -69,11 +69,11 @@ export class ClientService {
     /**
      *  Login to the API using metamask challenge result message.
      *  In order to get the object containing the message use `getChallenge` and handle Metamask login in the frontend.
-     * @param message message.value property contained in object returned from `getChallenge`.
+     * @param signature message.value property contained in object returned from `getChallenge`.
      * @return {Promise<JwtTokensInterface>}  Returns an object containing two tokens (access+refresh) that can be saved in storage.
      */
-    async loginWithMetamask(message: string): Promise<JwtTokensInterface | void> {
-        return await this.authService.loginWithMetamask(message)
+    async loginWithMetamask(signature: string): Promise<JwtTokensInterface | void> {
+        return await this.authService.loginWithMetamask(signature)
     }
 
     /**

--- a/src/apiServices/ClientService.ts
+++ b/src/apiServices/ClientService.ts
@@ -72,8 +72,8 @@ export class ClientService {
      * @param signature message.value property contained in object returned from `getChallenge`.
      * @return {Promise<JwtTokensInterface>}  Returns an object containing two tokens (access+refresh) that can be saved in storage.
      */
-    async loginWithMetamask(signature: string): Promise<JwtTokensInterface | void> {
-        return await this.authService.loginWithMetamask(signature)
+    async loginWithSignature(signature: string): Promise<JwtTokensInterface | void> {
+        return await this.authService.loginWithSignature(signature)
     }
 
     /**

--- a/src/apiServices/ClientService.ts
+++ b/src/apiServices/ClientService.ts
@@ -37,7 +37,7 @@ export class ClientService {
      */
     private toolName
 
-    constructor(ethAddress: string, password: string, toolName: string = 'MythXJS') {
+    constructor(ethAddress?: string, password?: string, toolName: string = 'MythXJS') {
         this.ethAddress = ethAddress
         this.password = password
         this.authService = new AuthService(ethAddress, password)
@@ -48,7 +48,11 @@ export class ClientService {
      *  Login to the API using ethAddress and password specified in the library constructor.
      * @return {Promise<JwtTokensInterface>}  Returns an object containing two tokens (access+refresh) that can be saved in storage.
      */
-    async login(): Promise<JwtTokensInterface> {
+    async login(ethAddress?: string, password?: string): Promise<JwtTokensInterface> {
+        if (ethAddress && password) {
+            this.ethAddress = ethAddress
+            this.password = password
+        }
         this.jwtTokens = await this.authService.login(this.ethAddress, this.password)
         this.analysesService = new AnalysesService(this.jwtTokens, this.toolName)
 

--- a/src/apiServices/ClientService.ts
+++ b/src/apiServices/ClientService.ts
@@ -67,6 +67,26 @@ export class ClientService {
     }
 
     /**
+     *  Login to the API using metamask challenge result message.
+     *  In order to get the message use `getChallenge` and handle Metamask login in the frontend.
+     * @param message string returned from `getChallenge`
+     * @return {Promise<JwtTokensInterface>}  Returns an object containing two tokens (access+refresh) that can be saved in storage.
+     */
+    async loginWithMetamask(message: string): Promise<JwtTokensInterface | void> {
+        return await this.authService.loginWithMetamask(message)
+    }
+
+    /**
+     *  Generates authentication challenge (Metamask only for now).
+     *  The Metamask flow needs to be handled on the front end since MythXJS does not have Web3 dependencies.
+     * @returns Resolves with API response or throw error
+     */
+
+    async getChallenge(): Promise<any | void> {
+        return await this.authService.getChallenge()
+    }
+
+    /**
      *  Logout from the API.
      * @returns Resolves with API response or throw error
      */

--- a/src/apiServices/ClientService.ts
+++ b/src/apiServices/ClientService.ts
@@ -68,7 +68,7 @@ export class ClientService {
 
     /**
      *  Login to the API using metamask challenge result message.
-     *  In order to get the message use `getChallenge` and handle Metamask login in the frontend.
+     *  In order to get the object containing the message use `getChallenge` and handle Metamask login in the frontend.
      * @param message string returned from `getChallenge`
      * @return {Promise<JwtTokensInterface>}  Returns an object containing two tokens (access+refresh) that can be saved in storage.
      */

--- a/src/apiServices/ClientService.ts
+++ b/src/apiServices/ClientService.ts
@@ -69,7 +69,7 @@ export class ClientService {
     /**
      *  Login to the API using metamask challenge result message.
      *  In order to get the object containing the message use `getChallenge` and handle Metamask login in the frontend.
-     * @param message string returned from `getChallenge`
+     * @param message message.value property contained in object returned from `getChallenge`.
      * @return {Promise<JwtTokensInterface>}  Returns an object containing two tokens (access+refresh) that can be saved in storage.
      */
     async loginWithMetamask(message: string): Promise<JwtTokensInterface | void> {

--- a/src/apiServices/ClientService.ts
+++ b/src/apiServices/ClientService.ts
@@ -86,11 +86,12 @@ export class ClientService {
     /**
      *  Generates authentication challenge (Metamask only for now).
      *  The Metamask flow needs to be handled on the front end since MythXJS does not have Web3 dependencies.
+     * @param ethAddress Ethereum address for Mythx account
      * @returns Resolves with API response or throw error
      */
 
-    async getChallenge(): Promise<any | void> {
-        return await this.authService.getChallenge()
+    async getChallenge(ethAddress?: string): Promise<any | void> {
+        return await this.authService.getChallenge(ethAddress)
     }
 
     /**

--- a/src/apiServices/ClientService.ts
+++ b/src/apiServices/ClientService.ts
@@ -46,6 +46,8 @@ export class ClientService {
 
     /**
      *  Login to the API using ethAddress and password specified in the library constructor.
+     * @param ethAddress Ethereum address for Mythx account
+     * @param password  Password for Ethereum address
      * @return {Promise<JwtTokensInterface>}  Returns an object containing two tokens (access+refresh) that can be saved in storage.
      */
     async login(ethAddress?: string, password?: string): Promise<JwtTokensInterface> {

--- a/src/test/authClass.getChallenge.spec.ts
+++ b/src/test/authClass.getChallenge.spec.ts
@@ -23,20 +23,20 @@ describe('getChallenge', () => {
         expect(AUTH.getChallenge).to.be.a('function')
     })
 
-    it('returns a object'),
-        async () => {
-            const value = {
-                domain: { name: 'MythX API Platform' },
-                message: { value: 'message' },
-                primaryType: 'Challenge',
-                types: {},
-            }
-
-            getRequestStub.resolves({ data: value })
-
-            const result = await AUTH.getChallenge()
-            expect(result).to.deep.equal(value)
+    it('returns a object', async () => {
+        const value = {
+            domain: { name: 'MythX API Platform' },
+            message: { value: 'message' },
+            primaryType: 'Challenge',
+            types: {},
         }
+
+        getRequestStub.resolves({ data: value })
+
+        const result = await AUTH.getChallenge()
+        console.error(result)
+        expect(result).to.deep.equal(value)
+    })
 
     it('should fail if there is something wrong with the request', async () => {
         getRequestStub.throws('400')

--- a/src/test/authClass.getChallenge.spec.ts
+++ b/src/test/authClass.getChallenge.spec.ts
@@ -1,0 +1,51 @@
+import { expect } from 'chai'
+import * as sinon from 'sinon'
+
+import { AuthService } from '../apiServices/AuthService'
+
+const getRequest = require('../http/index')
+
+describe('getChallenge', () => {
+    let getRequestStub: any
+
+    let AUTH
+    beforeEach(() => {
+        getRequestStub = sinon.stub(getRequest, 'getRequest')
+
+        AUTH = new AuthService('user', 'password')
+    })
+
+    afterEach(() => {
+        getRequestStub.restore()
+    })
+
+    it('is a function', () => {
+        expect(AUTH.getChallenge).to.be.a('function')
+    })
+
+    it('returns a object'),
+        async () => {
+            const value = {
+                domain: { name: 'MythX API Platform' },
+                message: { value: 'message' },
+                primaryType: 'Challenge',
+                types: {},
+            }
+
+            getRequestStub.resolves({ data: value })
+
+            const result = await AUTH.getChallenge()
+            expect(result).to.deep.equal(value)
+        }
+
+    it('should fail if there is something wrong with the request', async () => {
+        getRequestStub.throws('400')
+
+        try {
+            await AUTH.getChallenge()
+            expect.fail('getChallenge should be rejected')
+        } catch (err) {
+            expect(err.message).to.equal('MythxJS. Error with your request. 400')
+        }
+    })
+})

--- a/src/test/authClass.loginWithMetamask.spec.ts
+++ b/src/test/authClass.loginWithMetamask.spec.ts
@@ -1,0 +1,57 @@
+import { expect } from 'chai'
+import * as sinon from 'sinon'
+
+import { AuthService } from '../apiServices/AuthService'
+import { JwtTokensInterface } from '..'
+
+const postRequest = require('../http/index')
+
+describe('loginWithMetamask', () => {
+    const tokens: JwtTokensInterface = {
+        access: 'access',
+        refresh: 'refresh',
+    }
+
+    let postRequestStub: any
+    let setCredentialsStub: any
+
+    let AUTH
+    beforeEach(() => {
+        postRequestStub = sinon.stub(postRequest, 'postRequest')
+
+        AUTH = new AuthService('user', 'password')
+        setCredentialsStub = sinon.stub(AUTH, 'setCredentials')
+    })
+
+    afterEach(() => {
+        postRequestStub.restore()
+
+        delete AUTH.jwtTokens
+    })
+
+    it('is a function', () => {
+        expect(AUTH.loginWithMetamask).to.be.a('function')
+    })
+
+    it('should return and set access and refresh tokens', async () => {
+        postRequestStub.resolves({
+            data: { jwtTokens: tokens },
+        })
+
+        const result = await AUTH.loginWithMetamask()
+
+        expect(setCredentialsStub.calledWith(tokens)).to.be.true
+        expect(result).to.equal(tokens)
+    })
+
+    it('should fail if there is something wrong with the request', async () => {
+        postRequestStub.throws('400')
+
+        try {
+            await AUTH.loginWithMetamask()
+            expect.fail('loginWithMetamask should be rejected')
+        } catch (err) {
+            expect(err.message).to.equal('MythxJS. Error with your request. 400')
+        }
+    })
+})

--- a/src/test/authClass.loginWithSignature.spec.ts
+++ b/src/test/authClass.loginWithSignature.spec.ts
@@ -13,14 +13,12 @@ describe('loginWithSignature', () => {
     }
 
     let postRequestStub: any
-    let setCredentialsStub: any
 
     let AUTH
     beforeEach(() => {
         postRequestStub = sinon.stub(postRequest, 'postRequest')
 
         AUTH = new AuthService('user', 'password')
-        setCredentialsStub = sinon.stub(AUTH, 'setCredentials')
     })
 
     afterEach(() => {
@@ -40,7 +38,6 @@ describe('loginWithSignature', () => {
 
         const result = await AUTH.loginWithSignature()
 
-        expect(setCredentialsStub.calledWith(tokens)).to.be.true
         expect(result).to.equal(tokens)
     })
 

--- a/src/test/authClass.loginWithSignature.spec.ts
+++ b/src/test/authClass.loginWithSignature.spec.ts
@@ -6,7 +6,7 @@ import { JwtTokensInterface } from '..'
 
 const postRequest = require('../http/index')
 
-describe('loginWithMetamask', () => {
+describe('loginWithSignature', () => {
     const tokens: JwtTokensInterface = {
         access: 'access',
         refresh: 'refresh',
@@ -30,7 +30,7 @@ describe('loginWithMetamask', () => {
     })
 
     it('is a function', () => {
-        expect(AUTH.loginWithMetamask).to.be.a('function')
+        expect(AUTH.loginWithSignature).to.be.a('function')
     })
 
     it('should return and set access and refresh tokens', async () => {
@@ -38,7 +38,7 @@ describe('loginWithMetamask', () => {
             data: { jwtTokens: tokens },
         })
 
-        const result = await AUTH.loginWithMetamask()
+        const result = await AUTH.loginWithSignature()
 
         expect(setCredentialsStub.calledWith(tokens)).to.be.true
         expect(result).to.equal(tokens)
@@ -48,8 +48,8 @@ describe('loginWithMetamask', () => {
         postRequestStub.throws('400')
 
         try {
-            await AUTH.loginWithMetamask()
-            expect.fail('loginWithMetamask should be rejected')
+            await AUTH.loginWithSignature()
+            expect.fail('loginWithSignature should be rejected')
         } catch (err) {
             expect(err.message).to.equal('MythxJS. Error with your request. 400')
         }


### PR DESCRIPTION
I have implemented the ability to get challenge and login with Metamask from MythXJS. 

The actual Metamask login should be implemented in the user front end for two simple reasons: We do not want to import Web3 since its a massive library and we can't handle different Metamask versions etc. in our library.

The easiest way for the user to handle this new functionality is to call `getChallenge()`, get the message out of the response object and pass this message as a parameter to `loginWithMetamask()`.

When instantiating the Client object there is probably no need to pass the `password` if using Metamask so thats something that could be refactored in the future and documented.

