### PR TITLE
Add support for noCacheLookup API parameter

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ export interface loginResponse {
 
 export interface AnalyzeOptions {
     toolName?: string
+    noCacheLookup?: boolean
     contractName?: string
     bytecode?: string
     sourceMap?: string

--- a/src/test/analysesClass.analyze.spec.ts
+++ b/src/test/analysesClass.analyze.spec.ts
@@ -52,6 +52,7 @@ describe('analyze', () => {
 
         const expected = {
             clientToolName: 'MythXJTest',
+            noCacheLookup: false,
             data: {
                 contractName: 'contractName',
                 bytecode: 'bytecode',
@@ -90,6 +91,7 @@ describe('analyze', () => {
     it('should fail if there is something wrong with the request', async () => {
         const options: AnalyzeOptions = {
             toolName: 'test',
+            noCacheLookup: false,
             contractName: 'contractName',
             bytecode: 'bytecode',
             sourceMap: 'sourceMap',

--- a/src/util/generateContractsRequests.ts
+++ b/src/util/generateContractsRequests.ts
@@ -50,5 +50,6 @@ export function generateAnalysisRequest(
     if (typeof options.sourceList !== 'undefined') result.data['sourceList'] = options.sourceList
     if (typeof options.solcVersion !== 'undefined') result.data['version'] = options.solcVersion
     if (typeof options.analysisMode !== 'undefined') result.data['analysisMode'] = options.analysisMode
+
     return result
 }

--- a/src/util/generateContractsRequests.ts
+++ b/src/util/generateContractsRequests.ts
@@ -24,20 +24,13 @@ export function generateSourceCodeRequest(sourceCode: string, contractName: stri
     }
 }
 
-export function generateAnalysisRequest(
-    options: AnalyzeOptions,
-    toolName: string = 'MythXJS',
-    noCacheLookup: boolean = false,
-) {
+export function generateAnalysisRequest(options: AnalyzeOptions, toolName: string = 'MythXJS') {
     if (options.toolName) {
         toolName = options.toolName
     }
-    if (options.noCacheLookup !== undefined) {
-        noCacheLookup = options.noCacheLookup
-    }
     let result = {
         clientToolName: toolName,
-        noCacheLookup: noCacheLookup,
+        noCacheLookup: options.noCacheLookup === undefined ? false : options.noCacheLookup,
         data: {},
     }
     if (typeof options.contractName !== 'undefined') result.data['contractName'] = options.contractName

--- a/src/util/generateContractsRequests.ts
+++ b/src/util/generateContractsRequests.ts
@@ -24,12 +24,20 @@ export function generateSourceCodeRequest(sourceCode: string, contractName: stri
     }
 }
 
-export function generateAnalysisRequest(options: AnalyzeOptions, toolName: string = 'MythXJS') {
+export function generateAnalysisRequest(
+    options: AnalyzeOptions,
+    toolName: string = 'MythXJS',
+    noCacheLookup: boolean = false,
+) {
     if (options.toolName) {
         toolName = options.toolName
     }
+    if (options.noCacheLookup !== undefined) {
+        noCacheLookup = options.noCacheLookup
+    }
     let result = {
         clientToolName: toolName,
+        noCacheLookup: noCacheLookup,
         data: {},
     }
     if (typeof options.contractName !== 'undefined') result.data['contractName'] = options.contractName
@@ -42,6 +50,5 @@ export function generateAnalysisRequest(options: AnalyzeOptions, toolName: strin
     if (typeof options.sourceList !== 'undefined') result.data['sourceList'] = options.sourceList
     if (typeof options.solcVersion !== 'undefined') result.data['version'] = options.solcVersion
     if (typeof options.analysisMode !== 'undefined') result.data['analysisMode'] = options.analysisMode
-
     return result
 }


### PR DESCRIPTION
## Brief
MythX OpenAPI [has support for optional `noCacheLookup` parameter](https://api.mythx.io/v1/openapi#operation/submitAnalysis), which is not yet implemented in MythXJS. This PR submits it's implementation.

## Changes
- Added `AnalyzeOptions.noCacheLookup` **optional** `boolean` property.
- Tweaked `generateAnalysisRequest()` to have `noCacheLookup` `boolean` argument with `false` value by default. It will be overriden if `options.noCacheLookup` is defined.
- Tweaked tests.

Regards, @blitz-1306.