### PR TITLE
UX20-69-jwt

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,6 @@ const loginWithMM = async () => {
         async (message) => {
             // Returns set of tokens
             const result = await mythx.loginWithSignature(message)
-            console.log(result, 'ress')
         }
     ).catch(err => console.error(err))
 }

--- a/src/apiServices/AnalysesService.ts
+++ b/src/apiServices/AnalysesService.ts
@@ -18,12 +18,11 @@ import { AnalysisList, AnalysisSubmission, DetectedIssues } from '../types'
 
 export class AnalysesService {
     private API_URL: string = ClientService.MYTHX_API_ENVIRONMENT
-    private jwtTokens: JwtTokensInterface
     private toolName: string
 
     constructor(jwtTokens: JwtTokensInterface, toolName: string = 'MythXJS') {
         if (isTokenValid(jwtTokens.access)) {
-            this.jwtTokens = jwtTokens as JwtTokensInterface
+            ClientService.jwtTokens = jwtTokens as JwtTokensInterface
         } else {
             throw new Error('Access token has expired or is invalid! Please login again.')
         }
@@ -32,8 +31,8 @@ export class AnalysesService {
 
     public async getAnalysesList(): Promise<AnalysisList> {
         try {
-            const { headers, tokens } = await getHeaders(this.jwtTokens)
-            this.jwtTokens = tokens
+            const { headers, tokens } = await getHeaders(ClientService.jwtTokens)
+            this.setCredentials(tokens)
 
             const result = await getRequest(`${this.API_URL}/analyses`, headers)
             const analysisList: AnalysisList = result.data
@@ -47,8 +46,8 @@ export class AnalysesService {
 
     public async getAnalysisStatus(uuid: string): Promise<AnalysisSubmission> {
         try {
-            const { headers, tokens } = await getHeaders(this.jwtTokens)
-            this.jwtTokens = tokens
+            const { headers, tokens } = await getHeaders(ClientService.jwtTokens)
+            this.setCredentials(tokens)
 
             const result = await getRequest(`${this.API_URL}/analyses/${uuid}`, headers)
             const analysisRes: AnalysisSubmission = result.data
@@ -62,8 +61,8 @@ export class AnalysesService {
 
     public async getDetectedIssues(uuid: string): Promise<DetectedIssues> {
         try {
-            const { headers, tokens } = await getHeaders(this.jwtTokens)
-            this.jwtTokens = tokens
+            const { headers, tokens } = await getHeaders(ClientService.jwtTokens)
+            this.setCredentials(tokens)
 
             const getStatus = await this.getAnalysisStatus(uuid)
             if (getStatus.status === 'Queued' || getStatus.status === 'In progress') {
@@ -90,8 +89,8 @@ export class AnalysesService {
 
     public async submitBytecode(bytecode: string): Promise<AnalysisSubmission> {
         try {
-            const { headers, tokens } = await getHeaders(this.jwtTokens)
-            this.jwtTokens = tokens
+            const { headers, tokens } = await getHeaders(ClientService.jwtTokens)
+            this.setCredentials(tokens)
 
             const request = generateBytecodeRequest(bytecode, this.toolName)
 
@@ -107,8 +106,8 @@ export class AnalysesService {
 
     public async submitSourceCode(sourceCode: string, contractName: string): Promise<AnalysisSubmission> {
         try {
-            const { headers, tokens } = await getHeaders(this.jwtTokens)
-            this.jwtTokens = tokens
+            const { headers, tokens } = await getHeaders(ClientService.jwtTokens)
+            this.setCredentials(tokens)
 
             const request = generateSourceCodeRequest(sourceCode, contractName, this.toolName)
 
@@ -124,8 +123,8 @@ export class AnalysesService {
 
     public async analyze(options: AnalyzeOptions): Promise<AnalysisSubmission> {
         try {
-            const { headers, tokens } = await getHeaders(this.jwtTokens)
-            this.jwtTokens = tokens
+            const { headers, tokens } = await getHeaders(ClientService.jwtTokens)
+            this.setCredentials(tokens)
 
             const request = generateAnalysisRequest(options, this.toolName)
 
@@ -141,8 +140,8 @@ export class AnalysesService {
 
     public async getPdf(uuid: string): Promise<any> {
         try {
-            const { headers, tokens } = await getHeaders(this.jwtTokens)
-            this.jwtTokens = tokens
+            const { headers, tokens } = await getHeaders(ClientService.jwtTokens)
+            this.setCredentials(tokens)
 
             const result = await getRequest(`${this.API_URL}/analyses/${uuid}/pdf-report`, headers)
             const pdfRes: any = result.data
@@ -156,8 +155,8 @@ export class AnalysesService {
 
     public async listGroups(queryString?): Promise<AnalysisGroups> {
         try {
-            const { headers, tokens } = await getHeaders(this.jwtTokens)
-            this.jwtTokens = tokens
+            const { headers, tokens } = await getHeaders(ClientService.jwtTokens)
+            this.setCredentials(tokens)
 
             const result = await getRequest(`${this.API_URL}/analysis-groups?${queryString}`, headers)
             const groupsRes: AnalysisGroups = result.data
@@ -174,8 +173,8 @@ export class AnalysesService {
             if (!groupId) {
                 throw new Error('MythXJS: Group ID is required to perform this operation')
             }
-            const { headers, tokens } = await getHeaders(this.jwtTokens)
-            this.jwtTokens = tokens
+            const { headers, tokens } = await getHeaders(ClientService.jwtTokens)
+            this.setCredentials(tokens)
 
             const result = await getRequest(`${this.API_URL}/analysis-groups/${groupId}`, headers)
             const groupRes: Group = result.data
@@ -189,8 +188,8 @@ export class AnalysesService {
 
     public async createGroup(groupName?: string): Promise<Group> {
         try {
-            const { headers, tokens } = await getHeaders(this.jwtTokens)
-            this.jwtTokens = tokens
+            const { headers, tokens } = await getHeaders(ClientService.jwtTokens)
+            this.setCredentials(tokens)
 
             const body = groupName ? { groupName: groupName } : null
 
@@ -209,8 +208,8 @@ export class AnalysesService {
             if (!groupId) {
                 throw new Error('MythXJS: Group ID is required to perform this operation')
             }
-            const { headers, tokens } = await getHeaders(this.jwtTokens)
-            this.jwtTokens = tokens
+            const { headers, tokens } = await getHeaders(ClientService.jwtTokens)
+            this.setCredentials(tokens)
 
             const body = operationType ? { type: operationType } : 'seal_group'
 
@@ -222,5 +221,10 @@ export class AnalysesService {
             errorHandler(err)
             throw err
         }
+    }
+
+    private setCredentials(tokens: JwtTokensInterface) {
+        ClientService.jwtTokens.access = tokens.access
+        ClientService.jwtTokens.refresh = tokens.refresh
     }
 }

--- a/src/apiServices/AuthService.ts
+++ b/src/apiServices/AuthService.ts
@@ -175,7 +175,7 @@ export class AuthService {
     }
 
     private isUserLoggedIn() {
-        return !!ClientService.jwtTokens.access && !!ClientService.jwtTokens.refresh
+        return !!ClientService.jwtTokens.access
     }
 
     private setCredentials(tokens: JwtTokensInterface) {

--- a/src/apiServices/AuthService.ts
+++ b/src/apiServices/AuthService.ts
@@ -14,10 +14,6 @@ import { Openapi, Version } from '../types'
 export class AuthService {
     public ethAddress: string
     public password: string
-    public jwtTokens: JwtTokensInterface = {
-        access: '',
-        refresh: '',
-    }
     private API_URL = ClientService.MYTHX_API_ENVIRONMENT
 
     constructor(ethAddress?: string, password?: string) {
@@ -68,11 +64,11 @@ export class AuthService {
     public async logout(): Promise<{}> {
         if (this.isUserLoggedIn()) {
             try {
-                const { headers, tokens } = await getHeaders(this.jwtTokens)
-                this.jwtTokens = tokens
+                const { headers, tokens } = await getHeaders(ClientService.jwtTokens)
+                this.setCredentials(tokens)
 
                 const result = await postRequest(`${this.API_URL}/auth/logout`, {}, headers)
-                this.jwtTokens.access = this.jwtTokens.refresh = ''
+                ClientService.jwtTokens.access = ClientService.jwtTokens.refresh = ''
 
                 return result.data
             } catch (err) {
@@ -101,7 +97,7 @@ export class AuthService {
             const result = await getRequest(`${this.API_URL}/openapi`, null)
             const openApi: Openapi = result.data
 
-            return result.data
+            return openApi
         } catch (err) {
             errorHandler(err)
             throw err
@@ -121,8 +117,8 @@ export class AuthService {
     public async getStats(queryString?: string): Promise<Array<StatsResponse> | void> {
         if (this.isUserLoggedIn()) {
             try {
-                const { headers, tokens } = await getHeaders(this.jwtTokens)
-                this.jwtTokens = tokens
+                const { headers, tokens } = await getHeaders(ClientService.jwtTokens)
+                this.setCredentials(tokens)
 
                 const result = await getRequest(`${this.API_URL}/stats/users-analyses?${queryString}`, headers)
                 const stats: Array<StatsResponse> = result.data
@@ -146,6 +142,7 @@ export class AuthService {
         try {
             const address = ethAddress ? ethAddress : this.ethAddress
             const result = await getRequest(`${this.API_URL}/auth/challenge?ethAddress=${address}`, {})
+
             return result.data
         } catch (err) {
             errorHandler(err)
@@ -161,8 +158,8 @@ export class AuthService {
     public async getUsers(queryString: string = ''): Promise<UsersResponse> {
         if (this.isUserLoggedIn()) {
             try {
-                const { headers, tokens } = await getHeaders(this.jwtTokens)
-                this.jwtTokens = tokens
+                const { headers, tokens } = await getHeaders(ClientService.jwtTokens)
+                this.setCredentials(tokens)
 
                 const result = await getRequest(`${this.API_URL}/users?${queryString}`, headers)
                 const users: UsersResponse = result.data
@@ -178,11 +175,11 @@ export class AuthService {
     }
 
     private isUserLoggedIn() {
-        return !!this.jwtTokens.access && !!this.jwtTokens.refresh
+        return !!ClientService.jwtTokens.access && !!ClientService.jwtTokens.refresh
     }
 
     private setCredentials(tokens: JwtTokensInterface) {
-        this.jwtTokens.access = tokens.access
-        this.jwtTokens.refresh = tokens.refresh
+        ClientService.jwtTokens.access = tokens.access
+        ClientService.jwtTokens.refresh = tokens.refresh
     }
 }

--- a/src/apiServices/ClientService.ts
+++ b/src/apiServices/ClientService.ts
@@ -33,13 +33,18 @@ export class ClientService {
     /**
      * @ignore
      */
-    private jwtTokens
+    // private jwtTokens
     /**
      * @ignore
      */
     private toolName
 
     static MYTHX_API_ENVIRONMENT
+
+    static jwtTokens: JwtTokensInterface = {
+        access: '',
+        refresh: '',
+    }
 
     constructor(
         ethAddress?: string,
@@ -65,21 +70,10 @@ export class ClientService {
             this.ethAddress = ethAddress
             this.password = password
         }
-        this.jwtTokens = await this.authService.login(this.ethAddress, this.password)
-        this.analysesService = new AnalysesService(this.jwtTokens, this.toolName)
+        ClientService.jwtTokens = await this.authService.login(this.ethAddress, this.password)
+        this.analysesService = new AnalysesService(ClientService.jwtTokens, this.toolName)
 
-        return this.jwtTokens
-    }
-
-    /**
-     *  Login to the API using a set of pre-existing tokens.
-     *   Can be used when user has previously log in and stored those tokens in memory.
-     * @param jwtTokens object containing access + refresh token
-     * - example: loginWithToken({access:'foo', refresh: 'foo2'})
-     * @return {void}
-     */
-    loginWithToken(jwtTokens: JwtTokensInterface): void {
-        this.analysesService = new AnalysesService(jwtTokens)
+        return ClientService.jwtTokens
     }
 
     /**

--- a/src/apiServices/ClientService.ts
+++ b/src/apiServices/ClientService.ts
@@ -51,12 +51,16 @@ export class ClientService {
         password?: string,
         toolName: string = 'MythXJS',
         environment: string = 'https://api.mythx.io/v1',
+        accessToken: string = '',
     ) {
         this.ethAddress = ethAddress
         this.password = password
         ClientService.MYTHX_API_ENVIRONMENT = environment
         this.authService = new AuthService(ethAddress, password)
-        this.toolName = toolName
+        ;(this.toolName = toolName), (ClientService.jwtTokens.access = accessToken)
+        if (accessToken) {
+            this.analysesService = new AnalysesService(ClientService.jwtTokens, this.toolName)
+        }
     }
 
     /**
@@ -130,6 +134,7 @@ export class ClientService {
      * @returns {Promise<UsersResponse>} Resolves with API response or throw error
      */
     async getUsers(queryString: string): Promise<UsersResponse> {
+        console.log(ClientService.jwtTokens)
         return await this.authService.getUsers(queryString)
     }
 

--- a/src/apiServices/ClientService.ts
+++ b/src/apiServices/ClientService.ts
@@ -135,7 +135,6 @@ export class ClientService {
      * @returns {Promise<UsersResponse>} Resolves with API response or throw error
      */
     async getUsers(queryString: string): Promise<UsersResponse> {
-        console.log(ClientService.jwtTokens)
         return await this.authService.getUsers(queryString)
     }
 

--- a/src/apiServices/ClientService.ts
+++ b/src/apiServices/ClientService.ts
@@ -59,6 +59,7 @@ export class ClientService {
         this.authService = new AuthService(ethAddress, password)
         ;(this.toolName = toolName), (ClientService.jwtTokens.access = accessToken)
         if (accessToken) {
+            ClientService.jwtTokens.access = accessToken
             this.analysesService = new AnalysesService(ClientService.jwtTokens, this.toolName)
         }
     }

--- a/src/test/authService.logout.spec.ts
+++ b/src/test/authService.logout.spec.ts
@@ -3,6 +3,7 @@ import * as sinon from 'sinon'
 import * as jwt from 'jsonwebtoken'
 
 import { AuthService } from '../apiServices/AuthService'
+import { ClientService } from '../apiServices/ClientService'
 
 const postRequest = require('../http/index')
 
@@ -18,11 +19,12 @@ describe('logout', () => {
 
     let AUTH
     let isUserLoggedInStub: any
+    let CLIENT
     beforeEach(() => {
         postRequestStub = sinon.stub(postRequest, 'postRequest')
 
         AUTH = new AuthService('user', 'password')
-        AUTH.jwtTokens = {
+        ClientService.jwtTokens = {
             access: jwt.sign(accessToken, 'secret'),
             refresh: 'refresh',
         }
@@ -34,7 +36,7 @@ describe('logout', () => {
         postRequestStub.restore()
         isUserLoggedInStub.restore()
 
-        delete AUTH.jwtTokens
+        delete ClientService.jwtTokens
     })
 
     it('is a function', () => {
@@ -42,6 +44,7 @@ describe('logout', () => {
     })
 
     it('returns an empty object', async () => {
+        console.log('FOOOS')
         isUserLoggedInStub.returns(true)
 
         postRequestStub.resolves({

--- a/src/test/authService.logout.spec.ts
+++ b/src/test/authService.logout.spec.ts
@@ -44,7 +44,6 @@ describe('logout', () => {
     })
 
     it('returns an empty object', async () => {
-        console.log('FOOOS')
         isUserLoggedInStub.returns(true)
 
         postRequestStub.resolves({
@@ -68,7 +67,6 @@ describe('logout', () => {
 
     it('should fail if there is something wrong with the request', async () => {
         isUserLoggedInStub.returns(true)
-
         postRequestStub.throws('400')
 
         try {


### PR DESCRIPTION
I added a `accessToken` property to the constructor of ClientService. when this is passed that token will automatically be attached to all requests and there is no need to call `.login()`