### PR TITLE
Feat/add config object to constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,14 +25,6 @@ const mythx = new Client({
 });
 ```
 
-Performing a `login` request
-
-```typescript
-// Logs in and returns an object containing access and refresh token
-const tokens = await mythx.login()
-
-```
-
 Submitting an analysis using bytecode only
 
 ```typescript

--- a/README.md
+++ b/README.md
@@ -14,12 +14,15 @@ npm install mythxjs
 
 ## Example
 
-Creating a new instance of the library using ES6 modules
+Creating a new instance of the library using ES6 modules and pass in a config object
 
 ```typescript
 import { Client } from 'mythxjs'
 
-const mythx = new Client('0x0000000000000000000000000000000000000000', 'trial', 'testTool');
+const mythx = new Client({
+  username: '<your registered MythX email or EthAddress>',
+  apiKey: '<your mythx API key. see https://docs.mythx.io/#using-your-account for help>'
+});
 ```
 
 Performing a `login` request

--- a/src/apiServices/ClientService.ts
+++ b/src/apiServices/ClientService.ts
@@ -1,4 +1,12 @@
-import { AnalysisGroups, AnalyzeOptions, Group, JwtTokensInterface, StatsResponse, UsersResponse } from '..'
+import {
+    AnalysisGroups,
+    AnalyzeOptions,
+    ClientConfig,
+    Group,
+    JwtTokensInterface,
+    StatsResponse,
+    UsersResponse,
+} from '..'
 import { AnalysisList, AnalysisSubmission, DetectedIssues, Version } from '../types'
 
 import { AnalysesService } from './AnalysesService'
@@ -46,21 +54,40 @@ export class ClientService {
         refresh: '',
     }
 
-    constructor(
-        ethAddress?: string,
-        password?: string,
-        toolName: string = 'MythXJS',
-        environment: string = 'https://api.mythx.io/v1',
-        accessToken: string = '',
-    ) {
-        this.ethAddress = ethAddress
-        this.password = password
-        ClientService.MYTHX_API_ENVIRONMENT = environment
-        this.authService = new AuthService(ethAddress, password)
-        ;(this.toolName = toolName), (ClientService.jwtTokens.access = accessToken)
-        if (accessToken) {
-            ClientService.jwtTokens.access = accessToken
+    constructor(clientConfig: ClientConfig)
+    // constructor(
+    //     ethAddress?: string,
+    //     password?: string,
+    //     toolName: string = 'MythXJS',
+    //     environment: string = 'https://api.mythx.io/v1',
+    //     accessToken: string = '',
+    // ) {
+    constructor(clientConfig: any) {
+        if (clientConfig.username && clientConfig.accessToken) {
+            this.ethAddress = clientConfig.username
+            ClientService.MYTHX_API_ENVIRONMENT = clientConfig.environment || 'https://api.mythx.io/v1'
+            this.authService = new AuthService(this.ethAddress)
+            ;(this.toolName = clientConfig.toolName || 'MythXJS'),
+                (ClientService.jwtTokens.access = clientConfig.accessToken)
+            ClientService.jwtTokens.access = clientConfig.accessToken
             this.analysesService = new AnalysesService(ClientService.jwtTokens, this.toolName)
+        } else {
+            const [
+                ethAddress,
+                password,
+                toolName = 'MythXJS',
+                environment = 'https://api.mythx.io/v1',
+                accessToken,
+            ]: any = arguments
+            this.ethAddress = ethAddress
+            this.password = password
+            ClientService.MYTHX_API_ENVIRONMENT = environment
+            this.authService = new AuthService(ethAddress, password)
+            ;(this.toolName = toolName), (ClientService.jwtTokens.access = accessToken)
+            if (accessToken) {
+                ClientService.jwtTokens.access = accessToken
+                this.analysesService = new AnalysesService(ClientService.jwtTokens, this.toolName)
+            }
         }
     }
 

--- a/src/apiServices/ClientService.ts
+++ b/src/apiServices/ClientService.ts
@@ -56,12 +56,11 @@ export class ClientService {
 
     constructor(clientConfig: ClientConfig)
     constructor(clientConfig: any) {
-        if (clientConfig.username && clientConfig.apiKey) {
+        if (String(clientConfig) === '[object Object]' && clientConfig.username && clientConfig.apiKey) {
             this.ethAddress = clientConfig.username
             ClientService.MYTHX_API_ENVIRONMENT = clientConfig.environment || 'https://api.mythx.io/v1'
             this.authService = new AuthService(this.ethAddress)
-            ;(this.toolName = clientConfig.toolName || 'MythXJS'),
-                (ClientService.jwtTokens.access = clientConfig.apiKey)
+            this.toolName = clientConfig.toolName || 'MythXJS'
             ClientService.jwtTokens.access = clientConfig.apiKey
             this.analysesService = new AnalysesService(ClientService.jwtTokens, this.toolName)
         } else {
@@ -76,9 +75,9 @@ export class ClientService {
             this.password = password
             ClientService.MYTHX_API_ENVIRONMENT = environment
             this.authService = new AuthService(ethAddress, password)
-            ;(this.toolName = toolName), (ClientService.jwtTokens.access = accessToken)
+            this.toolName = toolName
+            ClientService.jwtTokens.access = accessToken
             if (accessToken) {
-                ClientService.jwtTokens.access = accessToken
                 this.analysesService = new AnalysesService(ClientService.jwtTokens, this.toolName)
             }
         }

--- a/src/apiServices/ClientService.ts
+++ b/src/apiServices/ClientService.ts
@@ -56,13 +56,13 @@ export class ClientService {
 
     constructor(clientConfig: ClientConfig)
     constructor(clientConfig: any) {
-        if (clientConfig.username && clientConfig.accessToken) {
+        if (clientConfig.username && clientConfig.apiKey) {
             this.ethAddress = clientConfig.username
             ClientService.MYTHX_API_ENVIRONMENT = clientConfig.environment || 'https://api.mythx.io/v1'
             this.authService = new AuthService(this.ethAddress)
             ;(this.toolName = clientConfig.toolName || 'MythXJS'),
-                (ClientService.jwtTokens.access = clientConfig.accessToken)
-            ClientService.jwtTokens.access = clientConfig.accessToken
+                (ClientService.jwtTokens.access = clientConfig.apiKey)
+            ClientService.jwtTokens.access = clientConfig.apiKey
             this.analysesService = new AnalysesService(ClientService.jwtTokens, this.toolName)
         } else {
             const [

--- a/src/apiServices/ClientService.ts
+++ b/src/apiServices/ClientService.ts
@@ -55,13 +55,6 @@ export class ClientService {
     }
 
     constructor(clientConfig: ClientConfig)
-    // constructor(
-    //     ethAddress?: string,
-    //     password?: string,
-    //     toolName: string = 'MythXJS',
-    //     environment: string = 'https://api.mythx.io/v1',
-    //     accessToken: string = '',
-    // ) {
     constructor(clientConfig: any) {
         if (clientConfig.username && clientConfig.accessToken) {
             this.ethAddress = clientConfig.username

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,7 +72,7 @@ export interface Group {
 
 export interface ClientConfig {
     username: string
-    accessToken: string
+    apiKey: string
     environment?: string
     toolName?: string
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,3 +69,10 @@ export interface Group {
     numAnalyses: {}
     numVulnerabilities: {}
 }
+
+export interface ClientConfig {
+    username: string
+    accessToken: string
+    environment?: string
+    toolName?: string
+}


### PR DESCRIPTION
This PR adds the possibility of initializing a MythxJS Client with a config object, using named parameters. The current implementation was just using regular function arguments,  5 in total, most of them being empty or using default values when using an API key, which made it really awkward.

Before,
```js
const client = new Client (
        'myEmail@orEthAddress.orUserId,
         ' ',
         'MythXJS',
        'https://api.mythx.io/v1',
        'ecy9834798roeigsdjfslkfjlaksjdlskjdgldfksjg....')
```

Now,
```js
const client = new Client (
{
        username: 'myEmail@orEthAddress.orUserId,
        accessToken: 'ecy9834798roeigsdjfslkfjlaksjdlskjdgldfksjg....'
}
)
```

I wanted it to now be a breaking change, so that anyone wanting to use the parameters array still could, but JS doesn't support function implementation overloads, only declarations. So I defined two constructors, one of which receives the interface `ClientConfig` so that in TS projects the parameters will be recognized and another which just receives an untyped object. In the implementation I start by checking if the user has used a config object. Ideally I would check if the object implements the ClientConfig interface, but TS doesn't allow for this, since it's a static type checker and this would be a dynamic check.

If the user has not provided a valid config object, we default to the previous parameters array, which I access through the `arguments` property and de-structure the values alongside with the default values that existed before.